### PR TITLE
Improve the collapsing of team cards

### DIFF
--- a/_includes/team.html
+++ b/_includes/team.html
@@ -24,7 +24,7 @@
           <div class="card-feature">
             <h3 class="name">Rob Viglione</h3>
             <p class="title">SCIENTIST</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseRob" aria-expanded="true" aria-controls="collapseRob">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#rob" href="#collapseRob" aria-expanded="true" aria-controls="collapseRob">Read More</a>
           </div>
         </div>
         <div id="collapseRob" class="collapse" role="tabpanel" aria-labelledby="headingRob">
@@ -49,7 +49,7 @@
           <div class="card-feature">
             <h3 class="name">Rolf Versluis</h3>
             <p class="title">BUSINESS OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseRolf" aria-expanded="true" aria-controls="collapseRolf">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#rolf" href="#collapseRolf" aria-expanded="true" aria-controls="collapseRolf">Read More</a>
           </div>
         </div>
         <div id="collapseRolf" class="collapse" role="tabpanel" aria-labelledby="headingRolf">
@@ -72,7 +72,7 @@
           <div class="card-feature">
             <h3 class="name">Jane Lippencott</h3>
             <p class="title">ASIA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseJane" aria-expanded="true" aria-controls="collapseJane">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#jane" href="#collapseJane" aria-expanded="true" aria-controls="collapseJane">Read More</a>
           </div>
         </div>
         <div id="collapseJane" class="collapse" role="tabpanel" aria-labelledby="headingJane">
@@ -94,7 +94,7 @@
           <div class="card-feature">
             <h3 class="name">Jin Cai</h3>
             <p class="title">CHINA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseJin" aria-expanded="true" aria-controls="collapseJin">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#jin" href="#collapseJin" aria-expanded="true" aria-controls="collapseJin">Read More</a>
           </div>
         </div>
         <div id="collapseJin" class="collapse" role="tabpanel" aria-labelledby="headingJin">
@@ -116,7 +116,7 @@
           <div class="card-feature">
             <h3 class="name">Anson Lau</h3>
             <p class="title">HONG KONG OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseAnson" aria-expanded="true" aria-controls="collapseAnson">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#anson" href="#collapseAnson" aria-expanded="true" aria-controls="collapseAnson">Read More</a>
           </div>
         </div>
         <div id="collapseAnson" class="collapse" role="tabpanel" aria-labelledby="headingAnson">
@@ -137,7 +137,7 @@
           <div class="card-feature">
             <h3 class="name">Davit Mrelashvili</h3>
             <p class="title">EASTERN EUROPE OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseDavit" aria-expanded="true" aria-controls="collapseDavit">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#davit" href="#collapseDavit" aria-expanded="true" aria-controls="collapseDavit">Read More</a>
           </div>
         </div>
         <div id="collapseDavit" class="collapse" role="tabpanel" aria-labelledby="headingDavit">
@@ -159,7 +159,7 @@
           <div class="card-feature">
             <h3 class="name">Said Mammadov</h3>
             <p class="title">TURKEY OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseSaid" aria-expanded="true" aria-controls="collapseSaid">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#said" href="#collapseSaid" aria-expanded="true" aria-controls="collapseSaid">Read More</a>
           </div>
         </div>
         <div id="collapseSaid" class="collapse" role="tabpanel" aria-labelledby="headingSaid">
@@ -180,7 +180,7 @@
           <div class="card-feature">
             <h3 class="name">Arno Pfefferling</h3>
             <p class="title">GERMANY OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseArno" aria-expanded="true" aria-controls="collapseArno">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#arno" href="#collapseArno" aria-expanded="true" aria-controls="collapseArno">Read More</a>
           </div>
         </div>
         <div id="collapseArno" class="collapse" role="tabpanel" aria-labelledby="headingArno">
@@ -202,7 +202,7 @@
           <div class="card-feature">
             <h3 class="name">Rowan Stone</h3>
             <p class="title">UK OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseRowan" aria-expanded="true" aria-controls="collapseRowan">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#rowan" href="#collapseRowan" aria-expanded="true" aria-controls="collapseRowan">Read More</a>
           </div>
         </div>
         <div id="collapseRowan" class="collapse" role="tabpanel" aria-labelledby="headingRowan">
@@ -225,7 +225,7 @@
           <div class="card-feature">
             <h3 class="name">Andreas Widerøe</h3>
             <p class="title">SCANDINAVIA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseAndreas" aria-expanded="true" aria-controls="collapseAndreas">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#andreas" href="#collapseAndreas" aria-expanded="true" aria-controls="collapseAndreas">Read More</a>
           </div>
         </div>
         <div id="collapseAndreas" class="collapse" role="tabpanel" aria-labelledby="headingAndreas">
@@ -246,7 +246,7 @@
           <div class="card-feature">
             <h3 class="name">Adnan Javed</h3>
             <p class="title">AUSTRALIA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseAdnan" aria-expanded="true" aria-controls="collapseAdnan">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#adnan" href="#collapseAdnan" aria-expanded="true" aria-controls="collapseAdnan">Read More</a>
           </div>
         </div>
         <div id="collapseAdnan" class="collapse" role="tabpanel" aria-labelledby="headingAdnan">
@@ -267,7 +267,7 @@
           <div class="card-feature">
             <h3 class="name">Jose Faisca</h3>
             <p class="title">PORTUGAL OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseJose" aria-expanded="true" aria-controls="collapseJose">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#jose" href="#collapseJose" aria-expanded="true" aria-controls="collapseJose">Read More</a>
           </div>
         </div>
         <div id="collapseJose" class="collapse" role="tabpanel" aria-labelledby="headingJose">
@@ -288,7 +288,7 @@
           <div class="card-feature">
             <h3 class="name">Hugh Ayara</h3>
             <p class="title">KENYA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseHugh" aria-expanded="true" aria-controls="collapseHugh">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#hugh" href="#collapseHugh" aria-expanded="true" aria-controls="collapseHugh">Read More</a>
           </div>
         </div>
         <div id="collapseHugh" class="collapse" role="tabpanel" aria-labelledby="headingHugh">
@@ -309,7 +309,7 @@
           <div class="card-feature">
             <h3 class="name">Taiga Ikuta</h3>
             <p class="title">JAPAN OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseTaiga" aria-expanded="true" aria-controls="collapseTaiga">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#taiga" href="#collapseTaiga" aria-expanded="true" aria-controls="collapseTaiga">Read More</a>
           </div>
         </div>
         <div id="collapseTaiga" class="collapse" role="tabpanel" aria-labelledby="headingTaiga">
@@ -331,7 +331,7 @@
           <div class="card-feature">
             <h3 class="name">Carlo Vicari</h3>
             <p class="title">BUSINESS DEVELOPMENT</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseCarlo" aria-expanded="true" aria-controls="collapseCarlo">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#carlo" href="#collapseCarlo" aria-expanded="true" aria-controls="collapseCarlo">Read More</a>
           </div>
         </div>
         <div id="collapseCarlo" class="collapse" role="tabpanel" aria-labelledby="headingCarlo">
@@ -350,7 +350,7 @@
           <div class="card-feature">
             <h3 class="name">Crypto Media Hub</h3>
             <p class="title">LEAD MARKETING TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseCmh" aria-expanded="true" aria-controls="collapseCmh">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#cmh" href="#collapseCmh" aria-expanded="true" aria-controls="collapseCmh">Read More</a>
           </div>
         </div>
         <div id="collapseCmh" class="collapse" role="tabpanel" aria-labelledby="headingCmh">
@@ -375,7 +375,7 @@
           <div class="card-feature">
             <h3 class="name">Gustavo Fialho</h3>
             <p class="title">COMMUNITY MANAGEMENT</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseGustavo" aria-expanded="true" aria-controls="collapseGustavo">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#gustavo" href="#collapseGustavo" aria-expanded="true" aria-controls="collapseGustavo">Read More</a>
           </div>
         </div>
         <div id="collapseGustavo" class="collapse" role="tabpanel" aria-labelledby="headingGustavo">
@@ -394,7 +394,7 @@
           <div class="card-feature">
             <h3 class="name">Rosario Pabst</h3>
             <p class="title">PROJECT MANAGER | OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseRosario" aria-expanded="true" aria-controls="collapseRosario">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#rosario" href="#collapseRosario" aria-expanded="true" aria-controls="collapseRosario">Read More</a>
           </div>
         </div>
         <div id="collapseRosario" class="collapse" role="tabpanel" aria-labelledby="headingRosario">
@@ -413,7 +413,7 @@
           <div class="card-feature">
             <h3 class="name">Simran Dhillon</h3>
             <p class="title">CREATIVE DIRECTOR</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseSimran" aria-expanded="true" aria-controls="collapseSimran">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#simran" href="#collapseSimran" aria-expanded="true" aria-controls="collapseSimran">Read More</a>
           </div>
         </div>
         <div id="collapseSimran" class="collapse" role="tabpanel" aria-labelledby="headingSimran">
@@ -442,7 +442,7 @@
           <div class="card-feature">
             <h3 class="name">Steven Nerayoff</h3>
             <p class="title">STRATEGIC ADVISOR</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseSteven" aria-expanded="true" aria-controls="collapseSteven">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#steven" href="#collapseSteven" aria-expanded="true" aria-controls="collapseSteven">Read More</a>
           </div>
         </div>
         <div id="collapseSteven" class="collapse" role="tabpanel" aria-labelledby="headingSteven">
@@ -461,7 +461,7 @@
           <div class="card-feature">
             <h3 class="name">Charles Hoskinson</h3>
             <p class="title">STRATEGIC ADVISOR</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseCharles" aria-expanded="true" aria-controls="collapseCharles">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#charles" href="#collapseCharles" aria-expanded="true" aria-controls="collapseCharles">Read More</a>
           </div>
         </div>
         <div id="collapseCharles" class="collapse" role="tabpanel" aria-labelledby="headingCharles">
@@ -480,7 +480,7 @@
           <div class="card-feature">
             <h3 class="name">Ross Kenyon</h3>
             <p class="title">STRATEGIC ADVISOR</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseRoss" aria-expanded="true" aria-controls="collapseRoss">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#ross" href="#collapseRoss" aria-expanded="true" aria-controls="collapseRoss">Read More</a>
           </div>
         </div>
         <div id="collapseRoss" class="collapse" role="tabpanel" aria-labelledby="headingRoss">
@@ -509,7 +509,7 @@
           <div class="card-feature">
             <h3 class="name">William Wolf</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseWilliam" aria-expanded="true" aria-controls="collapseWilliam">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#william" href="#collapseWilliam" aria-expanded="true" aria-controls="collapseWilliam">Read More</a>
           </div>
         </div>
         <div id="collapseWilliam" class="collapse" role="tabpanel" aria-labelledby="headingWilliam">
@@ -530,7 +530,7 @@
           <div class="card-feature">
             <h3 class="name">Lukáš Bureš</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseLukas" aria-expanded="true" aria-controls="collapseLukas">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#lukas" href="#collapseLukas" aria-expanded="true" aria-controls="collapseLukas">Read More</a>
           </div>
         </div>
         <div id="collapseLukas" class="collapse" role="tabpanel" aria-labelledby="headingLukas">
@@ -549,7 +549,7 @@
           <div class="card-feature">
             <h3 class="name">Jake Tarren</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseJake" aria-expanded="true" aria-controls="collapseJake">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#jake" href="#collapseJake" aria-expanded="true" aria-controls="collapseJake">Read More</a>
           </div>
         </div>
         <div id="collapseJake" class="collapse" role="tabpanel" aria-labelledby="headingJake">
@@ -568,7 +568,7 @@
           <div class="card-feature">
             <h3 class="name">Kendrick Tan</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseKendrick" aria-expanded="true" aria-controls="collapseKendrick">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#kendrick" href="#collapseKendrick" aria-expanded="true" aria-controls="collapseKendrick">Read More</a>
           </div>
         </div>
         <div id="collapseKendrick" class="collapse" role="tabpanel" aria-labelledby="headingKendrick">
@@ -587,7 +587,7 @@
           <div class="card-feature">
             <h3 class="name">Mike Lorey</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseMike" aria-expanded="true" aria-controls="collapseMike">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#mike" href="#collapseMike" aria-expanded="true" aria-controls="collapseMike">Read More</a>
           </div>
         </div>
         <div id="collapseMike" class="collapse" role="tabpanel" aria-labelledby="headingMike">
@@ -610,7 +610,7 @@
           <div class="card-feature">
             <h3 class="name">anarch3</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseAnarch" aria-expanded="true" aria-controls="collapseAnarch">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#anarch" href="#collapseAnarch" aria-expanded="true" aria-controls="collapseAnarch">Read More</a>
           </div>
         </div>
         <div id="collapseAnarch" class="collapse" role="tabpanel" aria-labelledby="headingAnarch">
@@ -629,7 +629,7 @@
           <div class="card-feature">
             <h3 class="name">cronic</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseCronic" aria-expanded="true" aria-controls="collapseCronic">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#cronic" href="#collapseCronic" aria-expanded="true" aria-controls="collapseCronic">Read More</a>
           </div>
         </div>
         <div id="collapseCronic" class="collapse" role="tabpanel" aria-labelledby="headingCronic">
@@ -651,7 +651,7 @@
           <div class="card-feature">
             <h3 class="name">Wayne Dawson</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseWayne" aria-expanded="true" aria-controls="collapseWayne">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#wayne" href="#collapseWayne" aria-expanded="true" aria-controls="collapseWayne">Read More</a>
           </div>
         </div>
         <div id="collapseWayne" class="collapse" role="tabpanel" aria-labelledby="headingWayne">
@@ -673,7 +673,7 @@
           <div class="card-feature">
             <h3 class="name">Eli Moskowitz</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#team-accordion" href="#collapseEli" aria-expanded="true" aria-controls="collapseEli">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#eli" href="#collapseEli" aria-expanded="true" aria-controls="collapseEli">Read More</a>
           </div>
         </div>
         <div id="collapseEli" class="collapse" role="tabpanel" aria-labelledby="headingEli">

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -24,7 +24,7 @@
           <div class="card-feature">
             <h3 class="name">Rob Viglione</h3>
             <p class="title">SCIENTIST</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#rob" href="#collapseRob" aria-expanded="true" aria-controls="collapseRob">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.rob" href="#collapseRob" aria-expanded="true" aria-controls="collapseRob">Read More</a>
           </div>
         </div>
         <div id="collapseRob" class="collapse" role="tabpanel" aria-labelledby="headingRob">
@@ -49,7 +49,7 @@
           <div class="card-feature">
             <h3 class="name">Rolf Versluis</h3>
             <p class="title">BUSINESS OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#rolf" href="#collapseRolf" aria-expanded="true" aria-controls="collapseRolf">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.rolf" href="#collapseRolf" aria-expanded="true" aria-controls="collapseRolf">Read More</a>
           </div>
         </div>
         <div id="collapseRolf" class="collapse" role="tabpanel" aria-labelledby="headingRolf">
@@ -72,7 +72,7 @@
           <div class="card-feature">
             <h3 class="name">Jane Lippencott</h3>
             <p class="title">ASIA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#jane" href="#collapseJane" aria-expanded="true" aria-controls="collapseJane">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.jane" href="#collapseJane" aria-expanded="true" aria-controls="collapseJane">Read More</a>
           </div>
         </div>
         <div id="collapseJane" class="collapse" role="tabpanel" aria-labelledby="headingJane">
@@ -94,7 +94,7 @@
           <div class="card-feature">
             <h3 class="name">Jin Cai</h3>
             <p class="title">CHINA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#jin" href="#collapseJin" aria-expanded="true" aria-controls="collapseJin">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.jin" href="#collapseJin" aria-expanded="true" aria-controls="collapseJin">Read More</a>
           </div>
         </div>
         <div id="collapseJin" class="collapse" role="tabpanel" aria-labelledby="headingJin">
@@ -116,7 +116,7 @@
           <div class="card-feature">
             <h3 class="name">Anson Lau</h3>
             <p class="title">HONG KONG OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#anson" href="#collapseAnson" aria-expanded="true" aria-controls="collapseAnson">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.anson" href="#collapseAnson" aria-expanded="true" aria-controls="collapseAnson">Read More</a>
           </div>
         </div>
         <div id="collapseAnson" class="collapse" role="tabpanel" aria-labelledby="headingAnson">
@@ -137,7 +137,7 @@
           <div class="card-feature">
             <h3 class="name">Davit Mrelashvili</h3>
             <p class="title">EASTERN EUROPE OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#davit" href="#collapseDavit" aria-expanded="true" aria-controls="collapseDavit">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.davit" href="#collapseDavit" aria-expanded="true" aria-controls="collapseDavit">Read More</a>
           </div>
         </div>
         <div id="collapseDavit" class="collapse" role="tabpanel" aria-labelledby="headingDavit">
@@ -159,7 +159,7 @@
           <div class="card-feature">
             <h3 class="name">Said Mammadov</h3>
             <p class="title">TURKEY OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#said" href="#collapseSaid" aria-expanded="true" aria-controls="collapseSaid">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.said" href="#collapseSaid" aria-expanded="true" aria-controls="collapseSaid">Read More</a>
           </div>
         </div>
         <div id="collapseSaid" class="collapse" role="tabpanel" aria-labelledby="headingSaid">
@@ -180,7 +180,7 @@
           <div class="card-feature">
             <h3 class="name">Arno Pfefferling</h3>
             <p class="title">GERMANY OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#arno" href="#collapseArno" aria-expanded="true" aria-controls="collapseArno">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.arno" href="#collapseArno" aria-expanded="true" aria-controls="collapseArno">Read More</a>
           </div>
         </div>
         <div id="collapseArno" class="collapse" role="tabpanel" aria-labelledby="headingArno">
@@ -202,7 +202,7 @@
           <div class="card-feature">
             <h3 class="name">Rowan Stone</h3>
             <p class="title">UK OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#rowan" href="#collapseRowan" aria-expanded="true" aria-controls="collapseRowan">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.rowan" href="#collapseRowan" aria-expanded="true" aria-controls="collapseRowan">Read More</a>
           </div>
         </div>
         <div id="collapseRowan" class="collapse" role="tabpanel" aria-labelledby="headingRowan">
@@ -225,7 +225,7 @@
           <div class="card-feature">
             <h3 class="name">Andreas Widerøe</h3>
             <p class="title">SCANDINAVIA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#andreas" href="#collapseAndreas" aria-expanded="true" aria-controls="collapseAndreas">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.andreas" href="#collapseAndreas" aria-expanded="true" aria-controls="collapseAndreas">Read More</a>
           </div>
         </div>
         <div id="collapseAndreas" class="collapse" role="tabpanel" aria-labelledby="headingAndreas">
@@ -246,7 +246,7 @@
           <div class="card-feature">
             <h3 class="name">Adnan Javed</h3>
             <p class="title">AUSTRALIA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#adnan" href="#collapseAdnan" aria-expanded="true" aria-controls="collapseAdnan">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.adnan" href="#collapseAdnan" aria-expanded="true" aria-controls="collapseAdnan">Read More</a>
           </div>
         </div>
         <div id="collapseAdnan" class="collapse" role="tabpanel" aria-labelledby="headingAdnan">
@@ -267,7 +267,7 @@
           <div class="card-feature">
             <h3 class="name">Jose Faisca</h3>
             <p class="title">PORTUGAL OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#jose" href="#collapseJose" aria-expanded="true" aria-controls="collapseJose">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.jose" href="#collapseJose" aria-expanded="true" aria-controls="collapseJose">Read More</a>
           </div>
         </div>
         <div id="collapseJose" class="collapse" role="tabpanel" aria-labelledby="headingJose">
@@ -288,7 +288,7 @@
           <div class="card-feature">
             <h3 class="name">Hugh Ayara</h3>
             <p class="title">KENYA OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#hugh" href="#collapseHugh" aria-expanded="true" aria-controls="collapseHugh">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.hugh" href="#collapseHugh" aria-expanded="true" aria-controls="collapseHugh">Read More</a>
           </div>
         </div>
         <div id="collapseHugh" class="collapse" role="tabpanel" aria-labelledby="headingHugh">
@@ -309,7 +309,7 @@
           <div class="card-feature">
             <h3 class="name">Taiga Ikuta</h3>
             <p class="title">JAPAN OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#taiga" href="#collapseTaiga" aria-expanded="true" aria-controls="collapseTaiga">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.taiga" href="#collapseTaiga" aria-expanded="true" aria-controls="collapseTaiga">Read More</a>
           </div>
         </div>
         <div id="collapseTaiga" class="collapse" role="tabpanel" aria-labelledby="headingTaiga">
@@ -331,7 +331,7 @@
           <div class="card-feature">
             <h3 class="name">Carlo Vicari</h3>
             <p class="title">BUSINESS DEVELOPMENT</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#carlo" href="#collapseCarlo" aria-expanded="true" aria-controls="collapseCarlo">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.carlo" href="#collapseCarlo" aria-expanded="true" aria-controls="collapseCarlo">Read More</a>
           </div>
         </div>
         <div id="collapseCarlo" class="collapse" role="tabpanel" aria-labelledby="headingCarlo">
@@ -350,7 +350,7 @@
           <div class="card-feature">
             <h3 class="name">Crypto Media Hub</h3>
             <p class="title">LEAD MARKETING TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#cmh" href="#collapseCmh" aria-expanded="true" aria-controls="collapseCmh">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.cmh" href="#collapseCmh" aria-expanded="true" aria-controls="collapseCmh">Read More</a>
           </div>
         </div>
         <div id="collapseCmh" class="collapse" role="tabpanel" aria-labelledby="headingCmh">
@@ -375,7 +375,7 @@
           <div class="card-feature">
             <h3 class="name">Gustavo Fialho</h3>
             <p class="title">COMMUNITY MANAGEMENT</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#gustavo" href="#collapseGustavo" aria-expanded="true" aria-controls="collapseGustavo">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.gustavo" href="#collapseGustavo" aria-expanded="true" aria-controls="collapseGustavo">Read More</a>
           </div>
         </div>
         <div id="collapseGustavo" class="collapse" role="tabpanel" aria-labelledby="headingGustavo">
@@ -394,7 +394,7 @@
           <div class="card-feature">
             <h3 class="name">Rosario Pabst</h3>
             <p class="title">PROJECT MANAGER | OPERATIONS</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#rosario" href="#collapseRosario" aria-expanded="true" aria-controls="collapseRosario">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.rosario" href="#collapseRosario" aria-expanded="true" aria-controls="collapseRosario">Read More</a>
           </div>
         </div>
         <div id="collapseRosario" class="collapse" role="tabpanel" aria-labelledby="headingRosario">
@@ -413,7 +413,7 @@
           <div class="card-feature">
             <h3 class="name">Simran Dhillon</h3>
             <p class="title">CREATIVE DIRECTOR</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#simran" href="#collapseSimran" aria-expanded="true" aria-controls="collapseSimran">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.simran" href="#collapseSimran" aria-expanded="true" aria-controls="collapseSimran">Read More</a>
           </div>
         </div>
         <div id="collapseSimran" class="collapse" role="tabpanel" aria-labelledby="headingSimran">
@@ -442,7 +442,7 @@
           <div class="card-feature">
             <h3 class="name">Steven Nerayoff</h3>
             <p class="title">STRATEGIC ADVISOR</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#steven" href="#collapseSteven" aria-expanded="true" aria-controls="collapseSteven">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.steven" href="#collapseSteven" aria-expanded="true" aria-controls="collapseSteven">Read More</a>
           </div>
         </div>
         <div id="collapseSteven" class="collapse" role="tabpanel" aria-labelledby="headingSteven">
@@ -461,7 +461,7 @@
           <div class="card-feature">
             <h3 class="name">Charles Hoskinson</h3>
             <p class="title">STRATEGIC ADVISOR</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#charles" href="#collapseCharles" aria-expanded="true" aria-controls="collapseCharles">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.charles" href="#collapseCharles" aria-expanded="true" aria-controls="collapseCharles">Read More</a>
           </div>
         </div>
         <div id="collapseCharles" class="collapse" role="tabpanel" aria-labelledby="headingCharles">
@@ -480,7 +480,7 @@
           <div class="card-feature">
             <h3 class="name">Ross Kenyon</h3>
             <p class="title">STRATEGIC ADVISOR</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#ross" href="#collapseRoss" aria-expanded="true" aria-controls="collapseRoss">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.ross" href="#collapseRoss" aria-expanded="true" aria-controls="collapseRoss">Read More</a>
           </div>
         </div>
         <div id="collapseRoss" class="collapse" role="tabpanel" aria-labelledby="headingRoss">
@@ -509,7 +509,7 @@
           <div class="card-feature">
             <h3 class="name">William Wolf</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#william" href="#collapseWilliam" aria-expanded="true" aria-controls="collapseWilliam">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.william" href="#collapseWilliam" aria-expanded="true" aria-controls="collapseWilliam">Read More</a>
           </div>
         </div>
         <div id="collapseWilliam" class="collapse" role="tabpanel" aria-labelledby="headingWilliam">
@@ -530,7 +530,7 @@
           <div class="card-feature">
             <h3 class="name">Lukáš Bureš</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#lukas" href="#collapseLukas" aria-expanded="true" aria-controls="collapseLukas">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.lukas" href="#collapseLukas" aria-expanded="true" aria-controls="collapseLukas">Read More</a>
           </div>
         </div>
         <div id="collapseLukas" class="collapse" role="tabpanel" aria-labelledby="headingLukas">
@@ -549,7 +549,7 @@
           <div class="card-feature">
             <h3 class="name">Jake Tarren</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#jake" href="#collapseJake" aria-expanded="true" aria-controls="collapseJake">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.jake" href="#collapseJake" aria-expanded="true" aria-controls="collapseJake">Read More</a>
           </div>
         </div>
         <div id="collapseJake" class="collapse" role="tabpanel" aria-labelledby="headingJake">
@@ -568,7 +568,7 @@
           <div class="card-feature">
             <h3 class="name">Kendrick Tan</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#kendrick" href="#collapseKendrick" aria-expanded="true" aria-controls="collapseKendrick">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.kendrick" href="#collapseKendrick" aria-expanded="true" aria-controls="collapseKendrick">Read More</a>
           </div>
         </div>
         <div id="collapseKendrick" class="collapse" role="tabpanel" aria-labelledby="headingKendrick">
@@ -587,7 +587,7 @@
           <div class="card-feature">
             <h3 class="name">Mike Lorey</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#mike" href="#collapseMike" aria-expanded="true" aria-controls="collapseMike">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.mike" href="#collapseMike" aria-expanded="true" aria-controls="collapseMike">Read More</a>
           </div>
         </div>
         <div id="collapseMike" class="collapse" role="tabpanel" aria-labelledby="headingMike">
@@ -610,7 +610,7 @@
           <div class="card-feature">
             <h3 class="name">anarch3</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#anarch" href="#collapseAnarch" aria-expanded="true" aria-controls="collapseAnarch">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.anarch" href="#collapseAnarch" aria-expanded="true" aria-controls="collapseAnarch">Read More</a>
           </div>
         </div>
         <div id="collapseAnarch" class="collapse" role="tabpanel" aria-labelledby="headingAnarch">
@@ -629,7 +629,7 @@
           <div class="card-feature">
             <h3 class="name">cronic</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#cronic" href="#collapseCronic" aria-expanded="true" aria-controls="collapseCronic">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.cronic" href="#collapseCronic" aria-expanded="true" aria-controls="collapseCronic">Read More</a>
           </div>
         </div>
         <div id="collapseCronic" class="collapse" role="tabpanel" aria-labelledby="headingCronic">
@@ -651,7 +651,7 @@
           <div class="card-feature">
             <h3 class="name">Wayne Dawson</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#wayne" href="#collapseWayne" aria-expanded="true" aria-controls="collapseWayne">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.wayne" href="#collapseWayne" aria-expanded="true" aria-controls="collapseWayne">Read More</a>
           </div>
         </div>
         <div id="collapseWayne" class="collapse" role="tabpanel" aria-labelledby="headingWayne">
@@ -673,7 +673,7 @@
           <div class="card-feature">
             <h3 class="name">Eli Moskowitz</h3>
             <p class="title">CORE TECHNICAL TEAM</p>
-            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent="#eli" href="#collapseEli" aria-expanded="true" aria-controls="collapseEli">Read More</a>
+            <a class="btn btn-primary collapsed" data-toggle="collapse" data-parent=".card.eli" href="#collapseEli" aria-expanded="true" aria-controls="collapseEli">Read More</a>
           </div>
         </div>
         <div id="collapseEli" class="collapse" role="tabpanel" aria-labelledby="headingEli">


### PR DESCRIPTION
### The problem
Hi, while I'm bowstring website today, I found a behaviour that bugs me...
We can have multiple cards with details info being displayed in "Advisors" and "Development" section
![image](https://user-images.githubusercontent.com/10692276/35190542-39deb956-feb8-11e7-8aed-a6deed472b29.png)
But we cannot have the same feature for cards in the "Operations" section.
![image](https://user-images.githubusercontent.com/10692276/35190529-f8fdfeec-feb7-11e7-94ee-fd3282c00315.png)

### What's happening
With `<a ... data-toggle="collapse" data-parent="#team-accordion" ...>Read More</a>` each click will collapse all the cards inside `#team-accordion`, there are three #team-accordion, so the `#team-accordion` will only effect the first one, which is the container of the cards in "Operations section"

### What this PR does
Personally, I found it helpful to have lots of details info being displayed at the same time, so by restricting the `data-parent` to the card itself, we not can have this:
![image](https://user-images.githubusercontent.com/10692276/35190578-12d4446a-feb9-11e7-953f-76a9333d58df.png)
