### PR TITLE
Update Swing Wallet Links to Point at Github Documentation

### DIFF
--- a/wallets.html
+++ b/wallets.html
@@ -62,7 +62,7 @@ permalink: /wallets/
                 <h3>Ubuntu Linux</h3>
               </div>
               <div class="card-footer">
-                <a href="{{site.wallets.swing}}" target="_blank">{% t global.wallets.full-chain %}</a>
+                <a href="https://github.com/ZencashOfficial/zencash-swing-wallet-ui/blob/master/docs/ReleaseUbuntuRepository.md" target="_blank">{% t global.wallets.full-chain %}</a>
                 <a href="https://github.com/ZencashOfficial/arizen/releases/download/v1.1.5/Arizen-1.1.5-x86_64.AppImage" target="_blank">{% t global.wallets.lite-chain %}</a>
               </div>
             </div>

--- a/wallets.html
+++ b/wallets.html
@@ -36,7 +36,7 @@ permalink: /wallets/
                 <h3>Windows</h3>
               </div>
               <div class="card-footer">
-                <a href="https://github.com/ZencashOfficial/zencash-swing-wallet-ui/releases/download/0.80.5/ZENCashDesktopGUIWallet_0.80.5.zip " target="_blank">{% t global.wallets.full-chain %}</a>
+                <a href="https://github.com/ZencashOfficial/zencash-swing-wallet-ui/blob/master/docs/Release_0.80.5.md " target="_blank">{% t global.wallets.full-chain %}</a>
                 <a href="https://github.com/ZencashOfficial/arizen/releases/download/v1.1.5/Arizen.Setup.1.1.5.exe" target="_blank">{% t global.wallets.lite-chain %}</a>
               </div>
             </div>
@@ -49,7 +49,7 @@ permalink: /wallets/
                 <h3>Mac OS</h3>
               </div>
               <div class="card-footer">
-                <a href="https://github.com/ZencashOfficial/zencash-swing-wallet-ui/releases/download/0.81.0/ZENCashWallet-0.81.0.dmg" target="_blank">{% t global.wallets.full-chain %}</a>
+                <a href="https://github.com/ZencashOfficial/zencash-swing-wallet-ui/blob/master/docs/Release_0.81.0.md" target="_blank">{% t global.wallets.full-chain %}</a>
                 <a href="https://github.com/ZencashOfficial/arizen/releases/download/v1.1.5/Arizen-1.1.5.dmg" target="_blank">{% t global.wallets.lite-chain %}</a>
               </div>
             </div>


### PR DESCRIPTION
From @vaklinov on Discord:
```
Problem: The ZEN Wallets section: https://zencash.com/wallets/ currently has links directly to wallet executables e.g. clicking on full client follows link 
https://github.com/ZencashOfficial/zencash-swing-wallet-ui/releases/download/0.80.5/ZENCashDesktopGUIWallet_0.80.5.zip
This is not a good idea: Unless users see installation instructions, some of them may make mistakes. It is also important for users to see the warnings/disclaimer so as not to have wrong expectations. It is a fact that this wallet is not suitable for novice users, who do not understand the implications of keeping a blockchain synchronized etc.

Proposal:  clicking on full client could follow the link to the following three documents (latest releases):
Windows: https://github.com/ZencashOfficial/zencash-swing-wallet-ui/blob/master/docs/Release_0.80.5.md
Mac OS: https://github.com/ZencashOfficial/zencash-swing-wallet-ui/blob/master/docs/Release_0.81.0.md
Linux: https://github.com/ZencashOfficial/zencash-swing-wallet-ui/blob/master/docs/ReleaseUbuntuRepository.md